### PR TITLE
🧹 [code health] Remove unused import in LiveSports.kt

### DIFF
--- a/src/all/livesports/src/eu/kanade/tachiyomi/animeextension/all/livesports/LiveSports.kt
+++ b/src/all/livesports/src/eu/kanade/tachiyomi/animeextension/all/livesports/LiveSports.kt
@@ -13,7 +13,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
 import extensions.utils.Source
 import okhttp3.OkHttpClient
-import org.jsoup.nodes.Element
 
 class LiveSports :
     Source(),


### PR DESCRIPTION
🎯 **What:** Removed the unused `org.jsoup.nodes.Element` import in `src/all/livesports/src/eu/kanade/tachiyomi/animeextension/all/livesports/LiveSports.kt`.

💡 **Why:** Cleaning up unused imports improves the maintainability and readability of the codebase by reducing clutter.

✅ **Verification:** Verified locally using `./gradlew spotlessCheck` and running the tests for the extension module via `./gradlew src:all:livesports:test`.

✨ **Result:** A cleaner codebase with no unused imports in `LiveSports.kt`.

---
*PR created automatically by Jules for task [1000892450140772503](https://jules.google.com/task/1000892450140772503) started by @salmanbappi*