### PR TITLE
🧹 Remove unused import getPreferencesLazy in AllAnime

### DIFF
--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -23,7 +23,6 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import extensions.utils.Source
 import keiyoushi.utils.bodyString
-import keiyoushi.utils.getPreferencesLazy
 import keiyoushi.utils.parallelCatchingFlatMap
 import keiyoushi.utils.parseAs
 import keiyoushi.utils.toJsonBody


### PR DESCRIPTION
🎯 **What:** Removed unused import `keiyoushi.utils.getPreferencesLazy`.
💡 **Why:** Cleans up the code to improve readability and maintainability.
✅ **Verification:** Ran `./gradlew check` and Spotless formatting tasks.
✨ **Result:** Improved code health without changing functionality.

---
*PR created automatically by Jules for task [1175613040372517733](https://jules.google.com/task/1175613040372517733) started by @salmanbappi*