### PR TITLE
🧪 Add comprehensive test suite for Crypto.kt `rc4` function

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -38,4 +38,10 @@ android {
 
 dependencies {
     compileOnly(versionCatalogs.named("libs").findBundle("common").get())
+    testImplementation(versionCatalogs.named("libs").findLibrary("junit").get())
+    testImplementation(versionCatalogs.named("libs").findLibrary("injekt-core").get())
+    testImplementation(versionCatalogs.named("libs").findLibrary("kotlin-json").get())
+    testImplementation(versionCatalogs.named("libs").findLibrary("okhttp").get())
+    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit"))
 }

--- a/core/src/test/kotlin/keiyoushi/utils/CryptoTest.kt
+++ b/core/src/test/kotlin/keiyoushi/utils/CryptoTest.kt
@@ -1,0 +1,55 @@
+package keiyoushi.utils
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class CryptoTest {
+
+    @Test
+    fun testRc4ThrowsOnEmptyKey() {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            rc4(ByteArray(0), "data".toByteArray())
+        }
+        assertEquals("RC4 key must not be empty", ex.message)
+    }
+
+    @Test
+    fun testRc4ThrowsOnKeyExceeding256Bytes() {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            rc4(ByteArray(257), "data".toByteArray())
+        }
+        assertEquals("RC4 key must not exceed 256 bytes, got 257", ex.message)
+    }
+
+    @Test
+    fun testRc4ThrowsOnNegativeSkip() {
+        val ex = assertThrows(IllegalArgumentException::class.java) {
+            rc4(ByteArray(16), "data".toByteArray(), skip = -1)
+        }
+        assertEquals("RC4 skip must be non-negative, got -1", ex.message)
+    }
+
+    @Test
+    fun testRc4EncryptionAndDecryption() {
+        val key = "secret_key".toByteArray()
+        val data = "hello world".toByteArray()
+
+        val encrypted = rc4(key, data)
+        val decrypted = rc4(key, encrypted)
+
+        assertArrayEquals(data, decrypted)
+    }
+
+    @Test
+    fun testRc4WithSkip() {
+        val key = "secret_key".toByteArray()
+        val data = "hello world".toByteArray()
+
+        val encrypted = rc4(key, data, skip = 256)
+        val decrypted = rc4(key, encrypted, skip = 256)
+
+        assertArrayEquals(data, decrypted)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for testing missing error conditions for the `rc4()` method in `Crypto.kt` was addressed.
📊 **Coverage:** A new test case was added to verify `rc4()` throws `IllegalArgumentException` when the key exceeds 256 bytes. Furthermore, edge cases like empty keys, negative skip sizes, and the normal happy path (symmetric encryption/decryption) were added to enhance robustness. Missing testing dependencies were added to `core/build.gradle.kts` to fix test compilation issues.
✨ **Result:** Test coverage for `Crypto.kt` is improved, properly capturing and documenting expected `rc4()` validation failures and verifying correct symmetric behavior.

---
*PR created automatically by Jules for task [5837210438879505481](https://jules.google.com/task/5837210438879505481) started by @salmanbappi*